### PR TITLE
fix: correct seeder column name and Apache port for non-root container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN set -eux; \
         dom \
         xml; \
     \
-    a2enmod rewrite
+    a2enmod rewrite; \
+    sed -i 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf
 
 # OPcache is built-in on PHP 8.5; just configure it.
 RUN set -eux; \

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
       db:
         condition: service_healthy
     ports:
-      - "8080:80"
+      - "8080:8080"
     env_file:
       - ./.env
     environment:

--- a/database/seeders/StarCitizen/ProductionStatusTableSeeder.php
+++ b/database/seeders/StarCitizen/ProductionStatusTableSeeder.php
@@ -22,7 +22,7 @@ class ProductionStatusTableSeeder extends Seeder
             [
                 'id' => 1,
                 'slug' => 'undefined',
-                'translations' => json_encode([
+                'translation' => json_encode([
                     'en' => 'Undefined',
                     'de' => 'Undefiniert',
                 ], JSON_THROW_ON_ERROR),

--- a/database/seeders/StarCitizen/Vehicle/SizeTableSeeder.php
+++ b/database/seeders/StarCitizen/Vehicle/SizeTableSeeder.php
@@ -23,7 +23,7 @@ class SizeTableSeeder extends Seeder
             [
                 'id' => 1,
                 'slug' => 'undefined',
-                'translations' => json_encode([
+                'translation' => json_encode([
                     'en' => 'Undefined',
                     'de' => 'Undefiniert',
                 ], JSON_THROW_ON_ERROR),

--- a/database/seeders/StarCitizen/Vehicle/TypeTableSeeder.php
+++ b/database/seeders/StarCitizen/Vehicle/TypeTableSeeder.php
@@ -23,7 +23,7 @@ class TypeTableSeeder extends Seeder
             [
                 'id' => 1,
                 'slug' => 'undefined',
-                'translations' => json_encode([
+                'translation' => json_encode([
                     'en' => 'Undefined',
                     'de' => 'Undefiniert',
                 ], JSON_THROW_ON_ERROR),

--- a/docker/vhost.conf
+++ b/docker/vhost.conf
@@ -1,4 +1,4 @@
-<VirtualHost *:80>
+<VirtualHost *:8080>
     CustomLog ${APACHE_LOG_DIR}/access.log combined
     ErrorLog ${APACHE_LOG_DIR}/error.log
 


### PR DESCRIPTION
## Summary

- **Seeder column name fix**: The three seeders (`ProductionStatusTableSeeder`, `SizeTableSeeder`, `TypeTableSeeder`) used `'translations'` (plural) as the column name, but the corresponding migrations and models define the column as `'translation'` (singular). This causes `php artisan db:seed` to fail with `SQLSTATE[42703]: Undefined column: column "translations" does not exist`.
- **Apache port fix**: The Dockerfile sets `USER www-data` and compose.yaml sets `no-new-privileges:true`, but Apache was configured to listen on port 80 (a privileged port). This causes the API container to crash-loop with `(13)Permission denied: AH00072: make_sock: could not bind to address 0.0.0.0:80`. Changed Apache to listen on port 8080 instead.

## Test plan

- [ ] Run `php artisan db:seed` on a fresh database and verify all seeders complete without errors
- [ ] Verify the API container starts and stays healthy (no crash-loop)
- [ ] Verify the application is accessible on port 8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)